### PR TITLE
[Architecture] Installing PostCSS. [Feature] CSS Vars

### DIFF
--- a/assets/styles/vars.css
+++ b/assets/styles/vars.css
@@ -1,0 +1,77 @@
+:root {
+  /* --------------------------------------------
+  VARIABLE NAMING GUIDELINES
+  --[element]-[css-property]-[state]
+  --border-color;
+  --button-border-color;
+  --button-border-color-hover;
+  --------------------------------------------- */
+
+
+  /* Spacing
+  -------------------------------------------- */
+  --space-xs: 4px;
+  --space-sm: calc(var(--space-xs) * 2);  /* 8px */
+  --space-md: calc(var(--space-xs) * 3);  /* 12px */
+  --space-lg: calc(var(--space-xs) * 4);  /* 16px */
+  --space-xl: calc(var(--space-xs) * 6);  /* 24px */
+  --space-xx: calc(var(--space-xs) * 8);  /* 32px */
+  --space-xxx: calc(var(--space-xs) * 14); /* 56px */
+
+
+  /* Colors
+  -------------------------------------------- */
+  --color-pink-500: #FF3C6A;
+
+  --color-blue-700: #1F2B5A;
+  --color-blue-500: #394883;
+  --color-blue-300: #5D699B;
+  --color-blue-200: #D4D9E3;
+  --color-blue-100: #E7E9F3;
+
+  --color-gray-600: #333333;
+  --color-gray-500: #535353;
+  --color-gray-400: #888888;
+  --color-gray-300: #B5B5B5;
+  --color-gray-200: #F3F3F3;
+  --color-gray-100: #FAFBFC;
+
+  --color-white: #FFF;
+  --color-black: #000;
+
+
+  /* Typography
+  -------------------------------------------- */
+  --font-family: Helvetica, Arial, sans-serif;
+
+  --font-color: var(--color-gray-500);
+  --font-size: 12px;
+
+  --font-weight: 400;
+  --font-weight-light: 300;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
+
+  --line-height-sm: 1em;
+  --line-height-md: 1.5em;
+  --line-height: var(--line-height-md);
+
+
+  /* Borders
+  -------------------------------------------- */
+  --border-radius: 4px;
+
+
+  /* Transitions
+  -------------------------------------------- */
+  --transition-time: 0.15s;
+  --transition-easing: cubic-bezier(.25,.46,.45,.94);
+  --transition: var(--transition-time) var(--transition-easing);
+}
+
+/* Media Queries
+-------------------------------------------- */
+@custom-media --mobile-up (min-width: 600px);
+@custom-media --tablet-up (min-width: 768px);
+@custom-media --lg-tablet-up (min-width: 992px);
+@custom-media --desktop-up (min-width: 1200px);

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 
 export default {
   mode: 'spa',
@@ -56,6 +57,39 @@ export default {
           exclude: /(node_modules)/,
         });
       }
-    }
+    },
+    postcss: {
+      // Add plugin names as key and arguments as value
+      // Install them before as dependencies with npm or yarn
+      plugins: {
+        'postcss-import': {
+          resolve(id) {
+            const aliases = {
+              Vars: path.resolve(__dirname, 'assets/styles/vars.css'),
+            };
+
+            for (let alias in aliases) {
+              if (id === alias) {
+                id = aliases[alias];
+              }
+            }
+
+            return id;
+          },
+        },
+        'postcss-nesting': {},
+        'postcss-custom-media': {},
+        'postcss-preset-env': {
+          browsers: 'last 2 versions',
+        },
+        cssnano: {},
+      },
+      preset: {
+        // Change the postcss-preset-env settings
+        autoprefixer: {
+          grid: true,
+        },
+      },
+    },
   }
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
     "eslint-loader": "^4.0.2",
     "eslint-plugin-jest": "^23.9.0",
     "eslint-plugin-prettier": "^3.1.3",
-    "eslint-plugin-vue": "^6.2.2"
+    "eslint-plugin-vue": "^6.2.2",
+    "postcss": "^7.0.29",
+    "postcss-custom-media": "^7.0.8",
+    "postcss-import": "^12.0.1",
+    "postcss-loader": "^3.0.0",
+    "postcss-nesting": "^7.0.1",
+    "postcss-preset-env": "^6.7.0"
   }
 }


### PR DESCRIPTION
### Problem
I need to setup my css and vars for future PR's/

**Task:** https://github.com/JacobRex/ui-challenge/projects/1#card-37770981

### Description
- Installs postcss and the plugins needed for this project
- Creates a vars file with the basics. This file will be expanded on as components are added.

### Why PostCSS?
- CSS variables are part of the css spec for most browsers now, so things like SASS are no longer necessary.
- By using css variables, we future proof our code by writing code that is intended to be supported by all browsers.
- PostCSS gives us conveniences like nesting, variables in media queries and more that we can tack on as needed, and PostCSS Preset Env will generate this in browser compatible ways for us. This means we can write future proof css with the conveniences we've come to love

### Considerations
- I established a css variable naming convention and put it in the vars file
- I use numbers for color variables (ex: --color-pink-500, --color-gray-100, etc). The thinking here is that the number is an indicator of how dark the color is. 500 is considered the "base" color, and lower numbers or less intense and higher numbers are more intense. 
- A benefit of this approach is that adding additional colors is easy, since you can just choose a number to fit it in the spectrum. 
- You can create separate semantic color names as needed, but also have the flexibility of generic names. For example, a button and a border might both use the "brand color" but if the brand color changes, it may not be the intent for the border to change also. For that reason, its best to go with generic names unless the variable is being used for the actual semantic purpose.