### PR TITLE
[Component] Layout

### DIFF
--- a/assets/styles/vars.css
+++ b/assets/styles/vars.css
@@ -41,6 +41,7 @@
 
   /* Layout
   -------------------------------------------- */
+  --layout-sider-width: 224px;
   --max-width: 970px;
 
 
@@ -49,7 +50,7 @@
   --font-family: Helvetica, Arial, sans-serif;
 
   --font-color: var(--color-gray-500);
-  --font-size: 12px;
+  --font-size: 14px;
 
   --font-weight: 400;
   --font-weight-light: 300;

--- a/components/Layout/index.js
+++ b/components/Layout/index.js
@@ -1,0 +1,15 @@
+import Layout from './src/Layout.vue';
+import LayoutHeader from './src/LayoutHeader.vue';
+import LayoutMain from './src/LayoutMain.vue';
+import LayoutSider from './src/LayoutSider.vue';
+import LayoutContent from './src/LayoutContent.vue';
+import LayoutFooter from './src/LayoutFooter.vue';
+
+export {
+  Layout as UiLayout,
+  LayoutHeader as UiLayoutHeader,
+  LayoutMain as UiLayoutMain,
+  LayoutSider as UiLayoutSider,
+  LayoutContent as UiLayoutContent,
+  LayoutFooter as UiLayoutFooter,
+};

--- a/components/Layout/src/Layout.vue
+++ b/components/Layout/src/Layout.vue
@@ -1,0 +1,49 @@
+<template>
+  <div
+    :class="[
+      $s.Layout,
+      $s[`variant_${variant}`]
+    ]"
+  >
+    <slot />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UiLayout',
+
+  props: {
+    variant: {
+      type: String,
+      default: 'normal',
+      validator: (value) => ['normal', 'backdrop'].includes(value),
+    },
+  },
+};
+</script>
+
+<style>
+body {
+  margin: 0;
+}
+</style>
+
+<style module="$s">
+@import 'Vars';
+
+.Layout {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  color: var(--font-color);
+  font-family: var(--font-family);
+  font-size: var(--font-size);
+  line-height: var(--line-height);
+  min-height: 100vh;
+
+  &.variant_backdrop {
+    background-color: var(--color-blue-100);
+  }
+}
+</style>

--- a/components/Layout/src/LayoutContent.vue
+++ b/components/Layout/src/LayoutContent.vue
@@ -1,0 +1,35 @@
+<template>
+  <div
+    :class="[
+      $s.LayoutContent,
+      { [$s.hasSider]: hasSider },
+    ]"
+  >
+    <slot />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UiLayoutContent',
+
+  props: {
+    hasSider: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>
+
+<style module="$s">
+@import 'Vars';
+
+.LayoutContent {
+  flex: 1;
+
+  &.hasSider {
+    margin-left: var(--space-xx);
+  }
+}
+</style>

--- a/components/Layout/src/LayoutContent.vue
+++ b/components/Layout/src/LayoutContent.vue
@@ -1,10 +1,5 @@
 <template>
-  <div
-    :class="[
-      $s.LayoutContent,
-      { [$s.hasSider]: hasSider },
-    ]"
-  >
+  <div :class="$s.LayoutContent">
     <slot />
   </div>
 </template>
@@ -12,13 +7,6 @@
 <script>
 export default {
   name: 'UiLayoutContent',
-
-  props: {
-    hasSider: {
-      type: Boolean,
-      default: false,
-    },
-  },
 };
 </script>
 
@@ -27,9 +15,5 @@ export default {
 
 .LayoutContent {
   flex: 1;
-
-  &.hasSider {
-    margin-left: var(--space-xx);
-  }
 }
 </style>

--- a/components/Layout/src/LayoutFooter.vue
+++ b/components/Layout/src/LayoutFooter.vue
@@ -1,0 +1,52 @@
+<template>
+  <footer
+    :class="[
+      $s.LayoutFooter,
+      $s[`variant_${variant}`]
+    ]"
+  >
+    <ui-container>
+      <slot />
+    </ui-container>
+  </footer>
+</template>
+
+<script>
+import { UiContainer } from 'Components/Container';
+
+export default {
+  name: 'UiLayoutContent',
+
+  components: {
+    UiContainer,
+  },
+
+  props: {
+    sticky: {
+      type: Boolean,
+      default: false,
+    },
+    variant: {
+      type: String,
+      default: 'normal',
+      validator: (value) => ['normal', 'backdrop'].includes(value),
+    },
+  },
+};
+</script>
+
+<style module="$s">
+@import 'Vars';
+
+.LayoutFooter {
+  padding: var(--space-xx) 0;
+
+  &.variant_normal {
+    background-color: var(--color-gray-200);
+  }
+
+  &.variant_backdrop {
+    background-color: var(--color-white);
+  }
+}
+</style>

--- a/components/Layout/src/LayoutHeader.vue
+++ b/components/Layout/src/LayoutHeader.vue
@@ -1,0 +1,34 @@
+<template>
+  <header
+    :class="[
+      $s.LayoutHeader,
+      { [$s.sticky]: sticky }
+    ]"
+  >
+    <slot />
+  </header>
+</template>
+
+<script>
+export default {
+  name: 'UiLayoutHeader',
+
+  props: {
+    sticky: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>
+
+<style module="$s">
+.LayoutHeader {
+  position: relative;
+
+  &.sticky {
+    position: sticky;
+    top: 0;
+  }
+}
+</style>

--- a/components/Layout/src/LayoutMain.vue
+++ b/components/Layout/src/LayoutMain.vue
@@ -1,0 +1,30 @@
+<template>
+  <main :class="$s.LayoutMain">
+    <div :class="$s.LayoutMainContent">
+      <slot />
+    </div>
+  </main>
+</template>
+
+<script>
+export default {
+  name: 'UiLayoutMain',
+};
+</script>
+
+<style module="$s">
+@import 'Vars';
+
+.LayoutMain {
+  flex: 1;
+  margin: var(--space-xl) 0;
+}
+
+.LayoutMainContent {
+  display: flex;
+  flex-wrap: wrap;
+  width: calc(100% - (2 * var(--space-xl)));
+  max-width: var(--max-width);
+  margin: auto;
+}
+</style>

--- a/components/Layout/src/LayoutSider.vue
+++ b/components/Layout/src/LayoutSider.vue
@@ -1,0 +1,19 @@
+<template>
+  <aside :class="$s.LayoutSider">
+    <slot />
+  </aside>
+</template>
+
+<script>
+export default {
+  name: 'UiLayoutSider',
+};
+</script>
+
+<style module="$s">
+@import 'Vars';
+
+.LayoutSider {
+  width: var(--layout-sider-width);
+}
+</style>

--- a/components/Layout/src/LayoutSider.vue
+++ b/components/Layout/src/LayoutSider.vue
@@ -15,5 +15,6 @@ export default {
 
 .LayoutSider {
   width: var(--layout-sider-width);
+  margin-right: var(--space-xx);
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,55 +1,36 @@
 <template>
-  <div>
-    <nuxt />
-  </div>
+  <ui-layout>
+    <ui-layout-header sticky>
+      Header
+    </ui-layout-header>
+
+    <ui-layout-main>
+      Main
+      <ui-layout-sider>
+        Sider
+      </ui-layout-sider>
+      <ui-layout-content has-sider>
+        <nuxt />
+      </ui-layout-content>
+    </ui-layout-main>
+
+    <ui-layout-footer>
+      Footer
+    </ui-layout-footer>
+  </ui-layout>
 </template>
 
-<style>
-html {
-  font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, 'Helvetica Neue', Arial, sans-serif;
-  font-size: 16px;
-  word-spacing: 1px;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  box-sizing: border-box;
-}
+<script>
+import { UiLayout, UiLayoutHeader, UiLayoutMain, UiLayoutSider, UiLayoutContent, UiLayoutFooter } from 'Components/Layout';
 
-*,
-*:before,
-*:after {
-  box-sizing: border-box;
-  margin: 0;
-}
-
-.button--green {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #3b8070;
-  color: #3b8070;
-  text-decoration: none;
-  padding: 10px 30px;
-}
-
-.button--green:hover {
-  color: #fff;
-  background-color: #3b8070;
-}
-
-.button--grey {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #35495e;
-  color: #35495e;
-  text-decoration: none;
-  padding: 10px 30px;
-  margin-left: 15px;
-}
-
-.button--grey:hover {
-  color: #fff;
-  background-color: #35495e;
-}
-</style>
+export default {
+  components: {
+    UiLayout,
+    UiLayoutHeader,
+    UiLayoutMain,
+    UiLayoutSider,
+    UiLayoutContent,
+    UiLayoutFooter,
+  },
+};
+</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -48,6 +48,11 @@ export default {
     ** You can extend webpack config here
     */
     extend (config, ctx) {
+      // Setup Aliases
+      config.resolve.alias = {
+        Components: path.resolve(__dirname, 'components'),
+      };
+
       // Run ESLint on save
       if (ctx.isDev && ctx.isClient) {
         config.module.rules.push({

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,72 +1,9 @@
 <template>
-  <div class="container">
-    <div>
-      <logo />
-      <h1 class="title">
-        ui-challenge
-      </h1>
-      <h2 class="subtitle">
-        UI Challenge project for Intricately
-      </h2>
-      <div class="links">
-        <a
-          href="https://nuxtjs.org/"
-          target="_blank"
-          class="button--green"
-        >
-          Documentation
-        </a>
-        <a
-          href="https://github.com/nuxt/nuxt.js"
-          target="_blank"
-          class="button--grey"
-        >
-          GitHub
-        </a>
-      </div>
-    </div>
+  <div>
+    Content
   </div>
 </template>
 
 <script>
-import Logo from '~/components/Logo.vue';
-
-export default {
-  components: {
-    Logo
-  }
-};
+export default {};
 </script>
-
-<style>
-.container {
-  margin: 0 auto;
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-}
-
-.title {
-  font-family: 'Quicksand', 'Source Sans Pro', -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  display: block;
-  font-weight: 300;
-  font-size: 100px;
-  color: #35495e;
-  letter-spacing: 1px;
-}
-
-.subtitle {
-  font-weight: 300;
-  font-size: 42px;
-  color: #526488;
-  word-spacing: 5px;
-  padding-bottom: 15px;
-}
-
-.links {
-  padding-top: 15px;
-}
-</style>


### PR DESCRIPTION
### Problem
- We need a way to create the overall structure of the application.
- We need a way to reset styles for fonts and such
- We need a root component to open layers in

**Task:** https://github.com/JacobRex/ui-challenge/projects/1#card-37771095

### Description
- Creates a webpack alias for the components director
- Adds a `--layout-sider-width` var and updates the base font size
- Adds a `Layout` component. This component resets body margins, and will distribute base font sizes and such since its the top most component. It leverages flex for the layout of other layout components. It has a single prop "variant" for choosing a "backdrop" style for the company page, which has a blue backdrop. To avoid an odd look for short pages, I made the min-width of the layout 100vh
- Adds a`LayoutHeader` component. Uses the `<header>` element. Can be made sticky with a prop.
- Adds `LayoutMain`, `LayoutSider` and `LayoutContent` components, which are meant to be sued together. Uses the `<main>`, `<aside>` and `<div>` elements.
- Adds a `LayoutFooter` component. It has a single prop "variant" for choosing a "backdrop" style for the company page, which has a white background instead of a grey background.
- Uses these components in the layout/page

### Considerations
- By leveraging provide/inject, we could strictly enforce the way these components could be nested. 
  - For example, we could make sure `LayoutSiders`/`LayoutContent` components are always inside a `LayoutMain`. 
  - We could even allow siders to be used on the left or right, and determine whether a left or right margin is needed
  - We could have a variant prop placed on the `Layout` trickle down to props in the child components. For example, if you applied a `backdrop` variant to your layout, we could automatically style the child components.
- Layout components could be expanded to have pre-determined responsive behavior. No such considerations have been made at this time due to time constraints.
- If layouts are only intended to be used one way, we could make these components less flexible and include more business logic. For example, maybe `LayoutHeaders` are always blue, negating the need for a navbar component.

---

![image](https://user-images.githubusercontent.com/11563996/81315039-6c2e2100-904f-11ea-91fa-21d96263a439.png)

