### PR TITLE
[Component] Heading

### DIFF
--- a/components/Heading/index.js
+++ b/components/Heading/index.js
@@ -1,0 +1,5 @@
+import Heading from './src/Heading.vue';
+
+export {
+  Heading as UiHeading,
+};

--- a/components/Heading/src/Heading.vue
+++ b/components/Heading/src/Heading.vue
@@ -1,0 +1,65 @@
+<template>
+  <component
+    :is="element"
+    :class="[
+      $s.Heading,
+      $s[`variant_${variant}`],
+    ]"
+  >
+    <slot />
+  </component>
+</template>
+
+<script>
+export default {
+  name: 'UiHeading',
+
+  props: {
+    element: {
+      type: String,
+      default: 'div',
+      validator: value => ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'p', 'span', 'label'].includes(value),
+    },
+    flush: {
+      type: Boolean,
+      default: false,
+    },
+    variant: {
+      type: String,
+      default: 'page-title',
+      validator: value => ['page-title', 'element-title'].includes(value),
+    }
+  },
+};
+</script>
+
+<style module="$s">
+@import 'Vars';
+
+.Heading {
+  margin-top: 0;
+  margin-bottom: 1em;
+  font-weight: var(--font-weight-regular);
+
+  &.flush {
+    margin-bottom: 0;
+  }
+}
+
+/* Variants
+---------------------------------------------- */
+.variant_page-title {
+  color: var(--color-gray-600);
+  font-size: 32px;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 1px;
+}
+
+.variant_element-title {
+  font-size: var(--font-size);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-sm);
+  letter-spacing: var(--letter-spacing);
+  text-transform: uppercase;
+}
+</style>

--- a/components/Layout/src/Layout.vue
+++ b/components/Layout/src/Layout.vue
@@ -27,6 +27,10 @@ export default {
 body {
   margin: 0;
 }
+
+h1, h2, h3, h4, h5, h6, p {
+  margin-top: 0;
+}
 </style>
 
 <style module="$s">


### PR DESCRIPTION
### Problem
We need a way to create headings in the app. Rather than let engineers manually define css each time a heading is needed, we can build a component to let them select from a handful of options.

**Task:** https://github.com/JacobRex/ui-challenge/projects/1#card-37771518

### Description
- Adds a Heading component
- Adds some more resets to the layout component

### Considerations
- I have a very limited understanding of the typography from the screenshots provided. An audit would need to be conducted to see what variants are needed. Depending on how flexible we need this component to be, we could strictly tie variants to a particular element. For example, maybe "page-title" headings are always `<h1>` elements. 
- We would also need to decide what constitutes a variant exactly. Font-size, font-weight, letter-spacing, line height and text transform, seem logical. Color probably can default to something, but should be able to be overruled with css in case the engineer is placing the heading over a colored background.
- I opted for semantic names for these headings. 

---

![image](https://user-images.githubusercontent.com/11563996/81329135-b1f4e480-9063-11ea-9108-ea4218e805ac.png)

