### PR TITLE
[Component] FormField

### DIFF
--- a/assets/styles/vars.css
+++ b/assets/styles/vars.css
@@ -23,6 +23,8 @@
   -------------------------------------------- */
   --color-pink-500: #FF3C6A;
 
+  --color-red-500: #A52929;
+
   --color-blue-700: #1F2B5A;
   --color-blue-500: #394883;
   --color-blue-300: #5D699B;
@@ -38,6 +40,10 @@
 
   --color-white: #FFF;
   --color-black: #000;
+
+  /* Semantic
+  -------------------------------------------- */
+  --color-danger: var(--color-red-500);
 
 
   /* Opacity

--- a/components/FormField/index.js
+++ b/components/FormField/index.js
@@ -1,0 +1,5 @@
+import FormField from './src/FormField.vue';
+
+export {
+  FormField as UiFormField,
+};

--- a/components/FormField/src/FormField.vue
+++ b/components/FormField/src/FormField.vue
@@ -1,0 +1,93 @@
+<template>
+  <div :class="$s.FormField">
+    <ui-heading
+      v-if="label"
+      :class="[
+        $s.Label,
+        { [$s.error]: error },
+      ]"
+      element="label"
+      variant="element-title"
+    >
+      {{ label }}
+    </ui-heading>
+    <div :class="$s.Field">
+      <slot />
+    </div>
+    <p
+      v-if="error"
+      :class="$s.ErrorText"
+    >
+      {{ error }}
+    </p>
+  </div>
+</template>
+
+<script>
+import { UiHeading } from 'Components/Heading';
+import FormFieldKey from './Key';
+
+export default {
+  name: 'UiFormField',
+
+  provide() {
+    return {
+      [FormFieldKey]: this.state,
+    };
+  },
+
+  inheritAttrs: false,
+
+  components: {
+    UiHeading,
+  },
+
+  props: {
+    error: {
+      type: String,
+      default: undefined,
+    },
+    label: {
+      type: String,
+      default: undefined,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      state: {
+        error: this.error,
+      }
+    };
+  },
+};
+</script>
+
+<style module="$s">
+@import "Vars";
+
+.FormField {
+  width: 100%;
+  margin-bottom: var(--space-xl);
+}
+
+/* Label
+---------------------------------------------- */
+.Label {
+  display: block;
+  margin-bottom: var(--space-sm);
+  color: var(--color-gray-300);
+
+  &.error {
+    color: var(--color-danger);
+  }
+}
+
+/* Errors
+---------------------------------------------- */
+.ErrorText {
+  margin-top: var(--space-sm);
+  color: var(--color-danger);
+}
+</style>

--- a/components/FormField/src/Key.js
+++ b/components/FormField/src/Key.js
@@ -1,0 +1,3 @@
+const FormFieldKey = Symbol('FormField');
+
+export default FormFieldKey;


### PR DESCRIPTION
### Problem
`Inputs` and `textareas` share labels, error messages and possibly more (such as a disabled state). This component will prevent handle these features to prevent this being implemented redundantly in multiple form components

**Task:** https://github.com/JacobRex/ui-challenge/projects/1#card-37771579

### Description
- Accepts a label string as a prop
- Accepts an error string as a prop
- Leverages provide/inject to pass the error state to a child for styling
- Adds a new red color for errors

---

![image](https://user-images.githubusercontent.com/11563996/81329869-cc7b8d80-9064-11ea-9c06-8327dc4762e6.png)
