### PR TITLE
[Fixed] Headings with flush prop

### DIFF
--- a/components/Heading/src/Heading.vue
+++ b/components/Heading/src/Heading.vue
@@ -4,6 +4,7 @@
     :class="[
       $s.Heading,
       $s[`variant_${variant}`],
+      { [$s.flush]: flush },
     ]"
   >
     <slot />


### PR DESCRIPTION
### Problem
`UiHeading` components using the `flush` prop still have a `margin-bottom`.

### Description
The class wasn't being applied. This PR adds that class.